### PR TITLE
I have made the plugin more customizable

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,7 +59,7 @@ def load(app):
     app.jinja_env.globals.update(oauth_clients=oauth_clients)
 
     # Update the login template
-    if get_app_config("OAUTH_CREATE_BUTTONS") == True:
+    if get_app_config("OAUTH_CREATE_BUTTONS").lower() == "true":
         update_login_template(app)
 
     # Register the blueprint containing the routes

--- a/blueprint.py
+++ b/blueprint.py
@@ -25,8 +25,8 @@ class OAuthForm(BaseForm):
     access_token_url = StringField("Access token url", validators=[InputRequired()])
     authorize_url = StringField("Authorization url", validators=[InputRequired()])
     api_base_url = StringField("User info url", validators=[InputRequired()])
-    admin_role = StringField("Admin SSO role", validators=[InputRequired()])
-    user_role = StringField("User SSO role", validators=[InputRequired()])
+    admin_role = StringField("Admin SSO role", validators=[InputRequired()], default=  "admin")
+    user_role = StringField("User SSO role", validators=[InputRequired()], default = "user")
     submit = SubmitField("Add")
 
 
@@ -82,6 +82,8 @@ def load_bp(oauth):
 
             return redirect(url_for('sso.sso_list'))
 
+        form.admin_role.data = "admin"
+        form.user_role.data = "user"
         form = OAuthForm()
         return render_template('create.html', form=form)
 

--- a/blueprint.py
+++ b/blueprint.py
@@ -82,9 +82,9 @@ def load_bp(oauth):
 
             return redirect(url_for('sso.sso_list'))
 
+        form = OAuthForm()
         form.admin_role.data = "admin"
         form.user_role.data = "user"
-        form = OAuthForm()
         return render_template('create.html', form=form)
 
 
@@ -102,7 +102,7 @@ def load_bp(oauth):
         api_data = client.get('').json()
         user_name = api_data["preferred_username"]
         user_email = api_data["email"]
-        if len(str(get_app_config("OAUTH_ROLES_SCOPE")).replace('\"', '')) > 0:
+        if get_app_config("OAUTH_ROLES_SCOPE") is not None and len(str(get_app_config("OAUTH_ROLES_SCOPE")).replace('\"', '')) > 0:
             user_roles = api_data.get(str(get_app_config("OAUTH_ROLES_SCOPE")).replace('\"', ''))
         else:
             user_roles = api_data.get("roles")

--- a/blueprint.py
+++ b/blueprint.py
@@ -25,6 +25,8 @@ class OAuthForm(BaseForm):
     access_token_url = StringField("Access token url", validators=[InputRequired()])
     authorize_url = StringField("Authorization url", validators=[InputRequired()])
     api_base_url = StringField("User info url", validators=[InputRequired()])
+    admin_role = StringField("Admin SSO role", validators=[InputRequired()])
+    user_role = StringField("User SSO role", validators=[InputRequired()])
     submit = SubmitField("Add")
 
 
@@ -59,6 +61,8 @@ def load_bp(oauth):
             access_token_url = request.form["access_token_url"]
             authorize_url = request.form["authorize_url"]
             api_base_url = request.form["api_base_url"]
+            admin_role = request.form["admin_role"]
+            user_role = request.form["user_role"]
 
             client = OAuthClients(
                 name=name,
@@ -66,7 +70,9 @@ def load_bp(oauth):
                 client_secret=client_secret,
                 access_token_url=access_token_url,
                 authorize_url=authorize_url,
-                api_base_url=api_base_url
+                api_base_url=api_base_url,
+                admin_role=admin_role,
+                user_role=user_role
             )
             db.session.add(client)
             db.session.commit()
@@ -119,7 +125,7 @@ def load_bp(oauth):
         user.verified = True
         db.session.commit()
 
-        if user_roles is not None and len(user_roles) > 0 and user_roles[0] in ["admin", "user"]:
+        if user_roles is not None and len(user_roles) > 0 and user_roles[0] in [OAuthClients.query.filter_by(client_id=client_id).first().admin_role, OAuthClients.query.filter_by(client_id=client_id).first().user_role]:
             user_role = user_roles[0]
             if user_role != user.type:
                 user.type = user_role

--- a/models.py
+++ b/models.py
@@ -11,6 +11,8 @@ class OAuthClients(db.Model):
     access_token_url = db.Column(db.Text)
     authorize_url = db.Column(db.Text)
     api_base_url = db.Column(db.Text)
+    admin_role = db.Column(db.Text)
+    user_role = db.Column(db.Text)
 
     # In a later update you will be able to customize the login button 
     color = db.Column(db.Text)
@@ -24,6 +26,8 @@ class OAuthClients(db.Model):
             access_token_url=self.access_token_url,
             authorize_url=self.authorize_url,
             api_base_url=self.api_base_url,
+            admin_role=self.admin_role,
+            user_role=self.user_role,
             client_kwargs={'scope': 'profile roles'}
         )
 

--- a/models.py
+++ b/models.py
@@ -20,11 +20,10 @@ class OAuthClients(db.Model):
     icon = db.Column(db.Text)
 
     def register(self, oauth):
-        if len(str(get_app_config("OAUTH_ALL_SCOPES")).replace('\"', '')) > 0:
+        if get_app_config("OAUTH_ALL_SCOPES") is not None and len(str(get_app_config("OAUTH_ALL_SCOPES")).replace('\"', '')) > 0:
             local_client_kwargs={'scope': str(get_app_config("OAUTH_ALL_SCOPES")).replace('\"', '')}
         else:
             local_client_kwargs={'scope': 'profile roles'}
-        print(local_client_kwargs)
         oauth.register(
             name=self.id,
             client_id=self.client_id,

--- a/models.py
+++ b/models.py
@@ -1,4 +1,5 @@
 from CTFd.models import db
+from CTFd.utils import get_app_config
 
 
 class OAuthClients(db.Model):
@@ -19,6 +20,11 @@ class OAuthClients(db.Model):
     icon = db.Column(db.Text)
 
     def register(self, oauth):
+        if len(str(get_app_config("OAUTH_ALL_SCOPES")).replace('\"', '')) > 0:
+            local_client_kwargs={'scope': str(get_app_config("OAUTH_ALL_SCOPES")).replace('\"', '')}
+        else:
+            local_client_kwargs={'scope': 'profile roles'}
+        print(local_client_kwargs)
         oauth.register(
             name=self.id,
             client_id=self.client_id,
@@ -28,7 +34,8 @@ class OAuthClients(db.Model):
             api_base_url=self.api_base_url,
             admin_role=self.admin_role,
             user_role=self.user_role,
-            client_kwargs={'scope': 'profile roles'}
+            client_kwargs=local_client_kwargs
+            
         )
 
     def disconnect(self, oauth):

--- a/templates/create.html
+++ b/templates/create.html
@@ -38,11 +38,11 @@
 				</div>
 				<div class="form-group">
 					<b>{{ form.admin_role.label }}</b>
-					{{ form.admin_role(class="form-control", value=admin_role) }}
+					{{ form.admin_role(class="form-control", value=form.admin_role.data) }}
 				</div>
 				<div class="form-group">
 					<b>{{ form.user_role.label }}</b>
-					{{ form.user_role(class="form-control", value=user_role) }}
+					{{ form.user_role(class="form-control", value=form.user_role.data) }}
 				</div>
 				<div class="row">
 					<div class="col">

--- a/templates/create.html
+++ b/templates/create.html
@@ -36,6 +36,14 @@
 					<b>{{ form.api_base_url.label }}</b>
 					{{ form.api_base_url(class="form-control", value=api_base_url) }}
 				</div>
+				<div class="form-group">
+					<b>{{ form.admin_role.label }}</b>
+					{{ form.admin_role(class="form-control", value=admin_role) }}
+				</div>
+				<div class="form-group">
+					<b>{{ form.user_role.label }}</b>
+					{{ form.user_role(class="form-control", value=user_role) }}
+				</div>
 				<div class="row">
 					<div class="col">
 						{{ form.submit(class="btn btn-md btn-primary btn-outlined") }}


### PR DESCRIPTION
I at home run Authelia, which uses different scopes for some reason, so I have made it so they can be more customized, plus you can now have as many user and admin roles defined per SSO in the create menu.

### 1. Customizable roles scopes and all scopes:
- Now in the `config.ini` file there are two more variables that can be set:
```
OAUTH_ROLES_SCOPE = ""
OAUTH_ALL_SCOPES = ""
```
- The first one controls what scope will be used for getting user roles, specifically for Authelia this is `groups`, if not set the default will be `roles`
- The second controls all of the scopes this plugin will try to access to get various data, for eg. you need the special `email` scope for Authelia to get the user email address. If not set the default will be `profile roles`
### 2. You can now assign what roles you want to be admin and user, it's not hardcoded anymore:
- I have added two new fields to the form, the database and the user role if statement
- The create SSO UI now shows those two new fields with the data being populated as `admin` and `user` respectably so the users just clicking 'next, next, finish' don't get confused

![image](https://github.com/r00tstici/CTFd-SSO-plugin/assets/71411196/56e44a63-62cc-4b56-b435-b65ddb747fac)

> The only thing to keep in mind is that the user will be assigned either an admin or user role based on what their Identity Provider gives as the first role so if you have `user, admin` you will be assigned a user role