### PR TITLE
Several improvement to CTFd-SSO-plugin 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Works perfectly with a large variety of identity management solutions, like KeyC
    - `OAUTH_HAS_ROLES`: set `True` if you want to allow automatic registration of administrators via OAuth. This relies on the API Endpoint returning the `roles` key. Default is `False`.
    - `OAUTH_CREATE_BUTTONS`: set `True` if you want to automatically add the OAuth login buttons in the login page. Default is `False`.
    - `OAUTH_NO_LOCAL_USERS`: set `True` if you only want to allow OAuth logins
+   - `OAUTH_SSO_LOGOUT`: set `True` if you wish for a logout from CTFd to force the logout from the OAuth provider. This requires that the provider supplies a `end_session_endpoint` in its server metadata.
 4. Start or restart CTFd.
 5. In the `Admin Panel` go to `Plugins`>`ctfd-sso`. There you can view and delete existing clients, or add a new one by pressing plus symbol.
 6. Insert a client name (it will be shown on the button) and the other information according to the identity provider. Then press `Add`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Works perfectly with a large variety of identity management solutions, like KeyC
 2. Install required python packages. If you are using Docker, it is done by rebuilding the container. Instead, if you are using other hosting solutions, you can install them with the command `pip3 install -r requirements.txt` from the plugin folder (`CTFd/plugins/CTFd-SSO-plugin`).
 3. Edit the `[extra]` section of `CTFd/config.ini` adding these two values:
    - `OAUTH_HAS_ROLES`: set `True` if you want to allow automatic registration of administrators via OAuth. This relies on the API Endpoint returning the `roles` key. Default is `False`.
+   - `OAUTH_ALLOWED_ADMIN_ROLES`: a comma separated list of roles that will be treated as administrators 
    - `OAUTH_CREATE_BUTTONS`: set `True` if you want to automatically add the OAuth login buttons in the login page. Default is `False`.
    - `OAUTH_NO_LOCAL_USERS`: set `True` if you only want to allow OAuth logins
    - `OAUTH_SSO_LOGOUT`: set `True` if you wish for a logout from CTFd to force the logout from the OAuth provider. This requires that the provider supplies a `end_session_endpoint` in its server metadata.
@@ -22,17 +23,17 @@ Works perfectly with a large variety of identity management solutions, like KeyC
 
 ## Automatic account creation
 
-If CTFd is configured to allow acccount creation, the user of OAuth for a missing account will create the account. The test for an existing account is based on the email address returned from the OAuth provider.
+If CTFd is configured to allow account creation, the user of OAuth for a missing account will create the account. The test for an existing account is based on the email address returned from the OAuth provider.
 
 The user is created based on the `id_token` returned from the OAuth server if `OAUTH_HAS_ROLES` is not set. Otherwise, as discussed below the user is created based on the `roles` key returned by the API Endpoint.
 
 ## Admin accounts
 
-If you want to automatically create admin accounts via the Identity Provider, make sure that the API Endpoint returns a key `roles` containing an array. The first element of that array will be set as the user role in CTFd.
+If you want to automatically create admin accounts via the Identity Provider, make sure that the API Endpoint returns a key `roles` containing an array.
 
 For example if an user should be admin, the Identity Provider should return something like: `{"preferred_username": "username", "email": "example@ctfd.org", "roles": ["admin"]}`
 
-The allowed roles for CTFd are `admin` and `user`, but the latter is set by default. This behavior is only possible with the `OAUTH_HAS_ROLES` configuration set. In this case the adminsitration role must be assigned to the user form the CTFd adminstration console.
+The allowed administrator roles for CTFd are determined by the list `OAUTH_ALLOWED_ADLIN_ROLES`, if a user has a role in this list they will be treated as an administrator. This behavior is only possible with the `OAUTH_HAS_ROLES` configuration set. In this other case the administration role must be assigned to the user form the CTFd administration console.
 
 ## Login buttons
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Works perfectly with a large variety of identity management solutions, like KeyC
 3. Edit the `[extra]` section of `CTFd/config.ini` adding these two values:
    - `OAUTH_ALWAYS_POSSIBLE`: set `True` if you want to allow registration via OAuth even if normal registration is turned off. Default is `False`.
    - `OAUTH_CREATE_BUTTONS`: set `True` if you want to automatically add the OAuth login buttons in the login page. Default is `False`.
+   - `OAUTH_NO_LOCAL_USERS`: set `True` if you only want to allow OAuth logins
 4. Start or restart CTFd.
 5. In the `Admin Panel` go to `Plugins`>`ctfd-sso`. There you can view and delete existing clients, or add a new one by pressing plus symbol.
 6. Insert a client name (it will be shown on the button) and the other information according to the identity provider. Then press `Add`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Works perfectly with a large variety of identity management solutions, like KeyC
 1. Clone this repository to [CTFd/plugins](https://github.com/CTFd/CTFd/tree/master/CTFd/plugins).
 2. Install required python packages. If you are using Docker, it is done by rebuilding the container. Instead, if you are using other hosting solutions, you can install them with the command `pip3 install -r requirements.txt` from the plugin folder (`CTFd/plugins/CTFd-SSO-plugin`).
 3. Edit the `[extra]` section of `CTFd/config.ini` adding these two values:
-   - `OAUTH_ALWAYS_POSSIBLE`: set `True` if you want to allow registration via OAuth even if normal registration is turned off. Default is `False`.
+   - `OAUTH_HAS_ROLES`: set `True` if you want to allow automatic registration of administrators via OAuth. This relies on the API Endpoint returning the `roles` key. Default is `False`.
    - `OAUTH_CREATE_BUTTONS`: set `True` if you want to automatically add the OAuth login buttons in the login page. Default is `False`.
    - `OAUTH_NO_LOCAL_USERS`: set `True` if you only want to allow OAuth logins
 4. Start or restart CTFd.
@@ -19,13 +19,19 @@ Works perfectly with a large variety of identity management solutions, like KeyC
 6. Insert a client name (it will be shown on the button) and the other information according to the identity provider. Then press `Add`.
 7. Log in :)
 
+## Automatic account creation
+
+If CTFd is configured to allow acccount creation, the user of OAuth for a missing account will create the account. The test for an existing account is based on the email address returned from the OAuth provider.
+
+The user is created based on the `id_token` returned from the OAuth server if `OAUTH_HAS_ROLES` is not set. Otherwise, as discussed below the user is created based on the `roles` key returned by the API Endpoint.
+
 ## Admin accounts
 
 If you want to automatically create admin accounts via the Identity Provider, make sure that the API Endpoint returns a key `roles` containing an array. The first element of that array will be set as the user role in CTFd.
 
 For example if an user should be admin, the Identity Provider should return something like: `{"preferred_username": "username", "email": "example@ctfd.org", "roles": ["admin"]}`
 
-The allowed roles for CTFd are `admin` and `user`, but the latter is set by default.
+The allowed roles for CTFd are `admin` and `user`, but the latter is set by default. This behavior is only possible with the `OAUTH_HAS_ROLES` configuration set. In this case the adminsitration role must be assigned to the user form the CTFd adminstration console.
 
 ## Login buttons
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Works perfectly with a large variety of identity management solutions, like KeyC
    - `OAUTH_CREATE_BUTTONS`: set `True` if you want to automatically add the OAuth login buttons in the login page. Default is `False`.
    - `OAUTH_NO_LOCAL_USERS`: set `True` if you only want to allow OAuth logins
    - `OAUTH_SSO_LOGOUT`: set `True` if you wish for a logout from CTFd to force the logout from the OAuth provider. This requires that the provider supplies a `end_session_endpoint` in its server metadata.
+   _ `OAUTH_VALIDATE_WITH_USERNAME`: By default the email is used to validate that the authenticated user exists. This is because it is generally immutable for most IdPs. In some cases the email might be mutable and the username immutable, in that case to avoid the vulnerability "CWE-290 - Authentication Bypass by Spoofing", this option should be set to `True`.
 4. Start or restart CTFd.
 5. In the `Admin Panel` go to `Plugins`>`ctfd-sso`. There you can view and delete existing clients, or add a new one by pressing plus symbol.
 6. Insert a client name (it will be shown on the button) and the other information according to the identity provider. Then press `Add`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works perfectly with a large variety of identity management solutions, like KeyC
    - `OAUTH_CREATE_BUTTONS`: set `True` if you want to automatically add the OAuth login buttons in the login page. Default is `False`.
    - `OAUTH_NO_LOCAL_USERS`: set `True` if you only want to allow OAuth logins
    - `OAUTH_SSO_LOGOUT`: set `True` if you wish for a logout from CTFd to force the logout from the OAuth provider. This requires that the provider supplies a `end_session_endpoint` in its server metadata.
-   _ `OAUTH_VALIDATE_WITH_USERNAME`: By default the email is used to validate that the authenticated user exists. This is because it is generally immutable for most IdPs. In some cases the email might be mutable and the username immutable, in that case to avoid the vulnerability "CWE-290 - Authentication Bypass by Spoofing", this option should be set to `True`.
+   - `OAUTH_VALIDATE_WITH_USERNAME`: By default the email is used to validate that the authenticated user exists. This is because it is generally immutable for most IdPs. In some cases the email might be mutable and the username immutable, in that case to avoid the vulnerability "CWE-290 - Authentication Bypass by Spoofing", this option should be set to `True`.
 4. Start or restart CTFd.
 5. In the `Admin Panel` go to `Plugins`>`ctfd-sso`. There you can view and delete existing clients, or add a new one by pressing plus symbol.
 6. Insert a client name (it will be shown on the button) and the other information according to the identity provider. Then press `Add`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Works perfectly with a large variety of identity management solutions, like KeyC
    - `OAUTH_NO_LOCAL_USERS`: set `True` if you only want to allow OAuth logins
    - `OAUTH_SSO_LOGOUT`: set `True` if you wish for a logout from CTFd to force the logout from the OAuth provider. This requires that the provider supplies a `end_session_endpoint` in its server metadata.
    - `OAUTH_VALIDATE_WITH_USERNAME`: By default the email is used to validate that the authenticated user exists. This is because it is generally immutable for most IdPs. In some cases the email might be mutable and the username immutable, in that case to avoid the vulnerability "CWE-290 - Authentication Bypass by Spoofing", this option should be set to `True`.
+   - `OAUTH_ALLOW_PRIVATE_METADATA`: set `True` to allow the OAuth metadata server to be on a private RFC 1918 address. Such an address might be used for an SSRF atrack, but is needed if your real OAuth server uses such an address.
 4. Start or restart CTFd.
 5. In the `Admin Panel` go to `Plugins`>`ctfd-sso`. There you can view and delete existing clients, or add a new one by pressing plus symbol.
 6. Insert a client name (it will be shown on the button) and the other information according to the identity provider. Then press `Add`.

--- a/__init__.py
+++ b/__init__.py
@@ -88,4 +88,4 @@ def load(app):
 
     if process_boolean_str(get_app_config("OAUTH_SSO_LOGOUT")):
         # Overwrite existing logout function to treat SSO logout
-        app.view_functions["auth.logout"] = bp.sso_logout
+        app.view_functions["auth.logout"] = app.view_functions["sso.sso_logout"]

--- a/__init__.py
+++ b/__init__.py
@@ -59,11 +59,6 @@ def update_challenge_template(app):
     """
     Gets the actual challenges template and injects an
     event listener to test is an SSO logout has occurred
-
-    This injection is needed so that clicking on the challenge buttons
-    after the refresh_token has expired will force an SSO login attempt.
-    It would be better if a failure of the fetch on "/api/v1/challenges/<id>"
-    forced the SSO login, but difficult to do from a plugin
     """
 
     environment = app.jinja_environment

--- a/__init__.py
+++ b/__init__.py
@@ -57,7 +57,7 @@ def update_login_template(app):
 
 def update_challenge_template(app):
     # This injection is needed so that clicking on the challenge buttons 
-    # After the refresh_token has expired will force an SSO login attempt.
+    # after the refresh_token has expired will force an SSO login attempt.
     # It would be better if a failure of the fetch on "/api/v1/challenges/<id>" 
     # forced the SSO login, but difficult to do from a plugin
     environment = app.jinja_environment

--- a/__init__.py
+++ b/__init__.py
@@ -85,3 +85,7 @@ def load(app):
 
     # Add a function to Jinja2 to count our active Oauth providers
     app.jinja_env.globals.update(numactive=numactive)
+
+    if process_boolean_str(get_app_config("OAUTH_SSO_LOGOUT")):
+        # Overwrite existing logout function to treat SSO logout
+        app.view_functions["auth.logout"] = bp.sso_logout

--- a/__init__.py
+++ b/__init__.py
@@ -27,6 +27,7 @@ def migrate_db():
     existing = {col['name'] for col in inspector.get_columns('oauth_clients')}
     migrations = [
         ('server_metadata_url', 'TEXT'),
+        ('enabled', 'BOOLEAN NOT NULL DEFAULT TRUE'),
     ]
     with db.engine.begin() as conn:
         for col_name, col_type in migrations:

--- a/__init__.py
+++ b/__init__.py
@@ -77,7 +77,8 @@ def update_challenge_template(app):
 def update_settings_template(app):
     """
     Gets the actual settings template and disabled the
-    name and email fields as treated by our IDP
+    name and email fields as treated by our IDP. If
+    OAUTH_NO_LOCAL_USERS is set, disbale password as well
     """
 
     environment = app.jinja_environment
@@ -91,6 +92,17 @@ def update_settings_template(app):
     if match:
         pos = match.end()
         original = original[:pos] + 'disabled=True, '+ original[pos:]
+
+    if process_boolean_str(get_app_config("OAUTH_NO_LOCAL_USERS")):
+        match = re.search('form.confirm\(', original)
+        if match:
+            pos = match.end()
+            original = original[:pos] + 'disabled=True, '+ original[pos:]
+
+        match = re.search('form.password\(', original)
+        if match:
+            pos = match.end()
+            original = original[:pos] + 'disabled=True, '+ original[pos:]
 
     override_template('settings.html', original)
 

--- a/__init__.py
+++ b/__init__.py
@@ -5,8 +5,10 @@ import os
 import re
 
 from authlib.integrations.flask_client import OAuth
+from sqlalchemy import inspect, text
 
 from CTFd.config import process_boolean_str
+from CTFd.models import db
 from CTFd.plugins import override_template
 from CTFd.utils import get_app_config
 
@@ -15,6 +17,22 @@ from .models import OAuthClients
 
 PLUGIN_PATH = os.path.dirname(__file__)
 CONFIG = json.load(open("{}/config.json".format(PLUGIN_PATH)))
+
+
+def migrate_db():
+    """Apply incremental schema changes to oauth_clients that create_all() won't add."""
+    inspector = inspect(db.engine)
+    if 'oauth_clients' not in inspector.get_table_names():
+        return  # Table doesn't exist yet; create_all() will build it fresh.
+    existing = {col['name'] for col in inspector.get_columns('oauth_clients')}
+    migrations = [
+        ('server_metadata_url', 'TEXT'),
+    ]
+    with db.engine.connect() as conn:
+        for col_name, col_type in migrations:
+            if col_name not in existing:
+                conn.execute(text(f'ALTER TABLE oauth_clients ADD COLUMN {col_name} {col_type}'))
+        conn.commit()
 
 
 def oauth_clients():
@@ -117,6 +135,9 @@ def numactive(clients):
 def load(app):
     # Create database tables
     app.db.create_all()
+
+    # Apply column-level migrations for existing tables
+    migrate_db()
 
     # Get all saved clients and register them
     clients = oauth_clients()

--- a/__init__.py
+++ b/__init__.py
@@ -28,11 +28,10 @@ def migrate_db():
     migrations = [
         ('server_metadata_url', 'TEXT'),
     ]
-    with db.engine.connect() as conn:
+    with db.engine.begin() as conn:
         for col_name, col_type in migrations:
             if col_name not in existing:
                 conn.execute(text(f'ALTER TABLE oauth_clients ADD COLUMN {col_name} {col_type}'))
-        conn.commit()
 
 
 def oauth_clients():

--- a/__init__.py
+++ b/__init__.py
@@ -96,7 +96,11 @@ def update_settings_template(app):
     """
     Gets the actual settings template and disabled the
     name and email fields as treated by our IDP. If
-    OAUTH_NO_LOCAL_USERS is set, disbale password as well
+    OAUTH_NO_LOCAL_USERS is set, disable password as well.
+
+    Yes the user can bypass this, but if they do the impact
+    is that they might loose access to CTFd.. Their problem,
+    not ours.
     """
 
     environment = app.jinja_environment

--- a/blueprint.py
+++ b/blueprint.py
@@ -31,7 +31,7 @@ class OAuthForm(BaseForm):
     client_secret = StringField("OAuth client secret", validators=[InputRequired()])
     access_token_url = StringField("Access token url", validators=[Optional()])
     authorize_url = StringField("Authorization url", validators=[Optional()])
-    api_base_url = StringField("User info url", validators=[Optional()])
+    api_base_url = StringField("Realm url", validators=[Optional()])
     server_metadata_url = StringField("Server metadata url", validators=[Optional()])
     color = StringField("Button Color", validators=[InputRequired()])
     enabled = BooleanField("Enabled")

--- a/blueprint.py
+++ b/blueprint.py
@@ -231,7 +231,7 @@ def load_bp(oauth):
         except:
             api_data = []
         try:
-            userinfo = client.parse_id_token(token)
+            userinfo = token["userinfo"]
         except:
             userinfo = []
 

--- a/blueprint.py
+++ b/blueprint.py
@@ -231,7 +231,9 @@ def load_bp(oauth):
         except:
             api_data = []
         try:
-            userinfo = token["userinfo"]
+            userinfo = token.get("userinfo")
+            if not userinfo:
+                userinfo = client.userinfo()
         except:
             userinfo = []
 

--- a/blueprint.py
+++ b/blueprint.py
@@ -347,14 +347,16 @@ def load_bp(oauth):
     @admins_only
     def sso_oauth_tokens():
         if request.method == 'GET':
-            clients = OAuthClients.query.all()
-            data = []
-            for client in clients:
-               data.append(client.json())
-            if data:
+            try:
+                clients = OAuthClients.query.all()
+                data = []
+                for client in clients:
+                   data.append(client.json())
+
                 return {"success": True, "data": data}
-            else:
-                return {"success": False}
+
+            except Exception as e:
+                return {"success": False, "errors": [str(e)]}
         else:
             try:
                 data = request.form or request.get_json()

--- a/blueprint.py
+++ b/blueprint.py
@@ -315,23 +315,24 @@ def load_bp(oauth):
             # Save end_session_endpoint for logout function
             metadata = client.load_server_metadata()
             session["sso_client_id"] = client_id
-            session["end_session_enpoint"] = metadata["end_session_endpoint"]
+            session["end_session_endpoint"] = metadata["end_session_endpoint"]
 
         return redirect(url_for("challenges.listing"))
 
 
     @plugin_bp.route("/sso/logout", methods = ['GET'])
     def sso_logout():
-        if current_user.authed():
-            logout_user()
-
         redirect_url = url_for("views.static_html")
         try:
             token = session["token"]
-            id_token = json.loads(token.replace("'", '"'))["id_token"]
+            id_token = token["id_token"]
             end_session_endpoint = session["end_session_endpoint"]
+            if current_user.authed():
+                logout_user()
             return redirect(end_session_endpoint + "?id_token_hint=" + id_token + "&post_logout_redirect_uri=" + redirect_url)
         except:
+            if current_user.authed():
+                logout_user()
             error_for(endpoint="views.static_html", message="No token or userinfo session data for SSO logout")
             return redirect(redirect_url)
 

--- a/blueprint.py
+++ b/blueprint.py
@@ -421,7 +421,7 @@ def load_bp(oauth):
                     client.client_id = data["enabled"]
                 if "server_metadata_url" in data:
                     client.server_metadata_url = data["server_metadata_url"]
-                    client.metadata = requests.get(server_metadata_url).json()
+                    metadata = requests.get(server_metadata_url).json()
                     client.access_token_url = metadata["token_endpoint"]
                     client.authorize_url = metadata["authorization_endpoint"]
                     client.api_base_url = metadata["issuer"]

--- a/blueprint.py
+++ b/blueprint.py
@@ -47,15 +47,16 @@ def load_bp(oauth):
         # CTFd is used. This is also used to impose the OAuth
         # providers idle time policy
 
-        # If on login page, pop rather than refresh the token. Avoid infinite loop
-        if request.path.endswith("/login"):
-            if "token" in session:
-                session.pop("token")
+        # If on login path or attempting SSO login/logout don't refresh
+        log("logins", "[{date}] {ip} - Path '{p}'", p=request.path)
+        if request.path.startswith("/login") or request.path.startswith("/sso/"):
+            return
+
+        # If no token then either not SSO or not logged in yet
+        if not "token" in session:
             return
 
         try:
-            if not "token" in session:
-                raise ValueError("SSO logout - missing token")
             token = session["token"]
 
             # If expiry of the access_token has not expired, don't refresh.

--- a/blueprint.py
+++ b/blueprint.py
@@ -279,10 +279,6 @@ def load_bp(oauth):
                 else:
                     return redirect(url_for("auth.login"))
 
-        # Set user.oauth_id to tell CTFd that user details are managed by our IDP
-        # Integer value, but the value doesn't mater
-        user.oauth_id = None
-
         user.verified = True
         db.session.commit()
 

--- a/blueprint.py
+++ b/blueprint.py
@@ -421,7 +421,7 @@ def load_bp(oauth):
                     client.client_id = data["enabled"]
                 if "server_metadata_url" in data:
                     client.server_metadata_url = data["server_metadata_url"]
-                    metadata = requests.get(server_metadata_url).json()
+                    metadata = requests.get(client.server_metadata_url).json()
                     client.access_token_url = metadata["token_endpoint"]
                     client.authorize_url = metadata["authorization_endpoint"]
                     client.api_base_url = metadata["issuer"]

--- a/blueprint.py
+++ b/blueprint.py
@@ -25,6 +25,7 @@ class OAuthForm(BaseForm):
     access_token_url = StringField("Access token url", validators=[InputRequired()])
     authorize_url = StringField("Authorization url", validators=[InputRequired()])
     api_base_url = StringField("User info url", validators=[InputRequired()])
+    color = StringField("Button Color", validators=[InputRequired()])
     enabled = BooleanField("Enabled")
     submit = SubmitField("Add")
 
@@ -55,6 +56,7 @@ def load_bp(oauth):
             client.access_token_url = request.form["access_token_url"]
             client.authorize_url = request.form["authorize_url"]
             client.api_base_url = request.form["api_base_url"]
+            client.color = request.form["color"]
             client.enabled = ("enabled" in request.form and request.form["enabled"] == "y")
             db.session.commit()
             db.session.flush()
@@ -70,6 +72,7 @@ def load_bp(oauth):
           form.access_token_url.data = client.access_token_url
           form.authorize_url.data = client.authorize_url
           form.api_base_url.data = client.api_base_url
+          form.color.data = client.color
           form.enabled.data = client.enabled
           form.submit.label.text = "Update"
 
@@ -86,8 +89,8 @@ def load_bp(oauth):
             access_token_url = request.form["access_token_url"]
             authorize_url = request.form["authorize_url"]
             api_base_url = request.form["api_base_url"]
+            color = request.form["color"]
             enabled = ("enabled" in request.form and request.form["enabled"] == "y")
-
 
             client = OAuthClients(
                 name=name,
@@ -96,6 +99,7 @@ def load_bp(oauth):
                 access_token_url=access_token_url,
                 authorize_url=authorize_url,
                 api_base_url=api_base_url,
+                color=color,
                 enabled=enabled
             )
             db.session.add(client)

--- a/blueprint.py
+++ b/blueprint.py
@@ -279,6 +279,10 @@ def load_bp(oauth):
                 else:
                     return redirect(url_for("auth.login"))
 
+        # Set user.oauth_id to tell CTFd that user details are managed by our IDP
+        # Integer value, but the value doesn't mater
+        user.oauth_id = None
+
         user.verified = True
         db.session.commit()
 

--- a/blueprint.py
+++ b/blueprint.py
@@ -47,9 +47,8 @@ def load_bp(oauth):
         # CTFd is used. This is also used to impose the OAuth
         # providers idle time policy
 
-        # If on login path or attempting SSO login/logout don't refresh
-        log("logins", "[{date}] {ip} - Path '{p}'", p=request.path)
-        if request.path.startswith("/login") or request.path.startswith("/sso/"):
+        # If on login path or attempting SSO login/logout don't refresh 
+        if request.path.startswith("/login") or request.path.startswith("/sso/"): 
             return
 
         # If no token then either not SSO or not logged in yet

--- a/blueprint.py
+++ b/blueprint.py
@@ -46,7 +46,40 @@ def load_bp(oauth):
                 db.session.delete(client)
                 db.session.commit()
                 db.session.flush()
-        return redirect(url_for('sso.sso_list'))
+            return redirect(url_for('sso.sso_list'))
+        elif request.method == "POST":
+            client = OAuthClients(
+                name=name,
+                client_id=client_id,
+                client_secret=client_secret,
+                access_token_url=access_token_url,
+                authorize_url=authorize_url,
+                api_base_url=api_base_url
+            )
+            client.name = request.form["name"]
+            client.client_id = request.form["client_id"]
+            client.client_secret = request.form["client_secret"]
+            client.access_token_url = request.form["access_token_url"]
+            client.authorize_url = request.form["authorize_url"]
+            client.api_base_url = request.form["api_base_url"]
+            db.session.commit()
+            db.session.flush()
+
+            client.update(oauth)
+
+            return redirect(url_for('sso.sso_list'))
+        else:
+          client = OAuthClients.query.filter_by(id=client_id).first()
+          form = OAuthForm()
+          form.name.data = client.name
+          form.client_id.data = client.client_id
+          form.client_secret.data = client.client_secret
+          form.access_token_url.data = client.access_token_url
+          form.authorize_url.data = client.authorize_url
+          form.api_base_url.data = client.api_base_url
+          form.submit.label.text = "Update"
+
+          return render_template('update.html', form=form)
 
 
     @plugin_bp.route('/admin/sso/create', methods = ['GET', 'POST'])

--- a/blueprint.py
+++ b/blueprint.py
@@ -131,7 +131,7 @@ def load_bp(oauth):
         client = oauth.create_client(client_id)
         token = client.authorize_access_token()
 
-        if process_boolean_str(get_app_config("OAUTH_ALWAYS_POSSIBLE")):
+        if process_boolean_str(get_app_config("OAUTH_HAS_ROLES")):
             api_data = client.get('').json()
             user_name = api_data["preferred_username"]
             user_email = api_data["email"]
@@ -148,7 +148,7 @@ def load_bp(oauth):
         user = Users.query.filter_by(email=user_email).first()
         if user is None:
             # Check if we are allowing registration before creating users
-            if registration_visible() or process_boolean_str(get_app_config("OAUTH_ALWAYS_POSSIBLE")):
+            if registration_visible():
                 user = Users(
                     name=user_name,
                     email=user_email,

--- a/blueprint.py
+++ b/blueprint.py
@@ -393,8 +393,8 @@ def load_bp(oauth):
                 client.register(oauth)
 
                 return {"success": True, "data": client.json()}
-            except:
-                return {"success": False}
+            except Exception as e:
+                return {"success": False, "errors": [str(e)]}
 
 
     @plugin_bp.route("/api/v1/sso/<int:client_id>", methods = ['GET', 'PATCH', 'DELETE'])
@@ -436,8 +436,8 @@ def load_bp(oauth):
                 db.session.flush()
                 client.register(oauth)
                 return {"success": True, "data": client.json()}
-            except:
-                return {"success": False}
+            except Exception as e:
+                return {"success": False, "errors": [str(e)]}
         elif request.method == "DELETE":
             try:
                 if client:
@@ -448,8 +448,8 @@ def load_bp(oauth):
                     return {"success": True}
                 else:
                     return {"success": False}
-            except:
-                return {"success": False}
+            except Exception as e:
+                return {"success": False, "errors": [str(e)]}
         else:
             return {"success": False}
 

--- a/blueprint.py
+++ b/blueprint.py
@@ -54,9 +54,10 @@ def load_bp(oauth):
         if not "token" in session:
             return response
         token = session["token"]
-        refresh_token = token["refresh_token"]
-        if not refresh_token:
+        if not "refresh_token" in token :
             session.pop("token")
+            return response
+        refresh_token = token["refresh_token"]
 
         # If expiry of the access_token is longer then 60 seconds
         # away, don't refresh. The refresh_token will expire

--- a/blueprint.py
+++ b/blueprint.py
@@ -1,8 +1,9 @@
 from flask import Blueprint, redirect, render_template, request, url_for
 from wtforms import StringField, BooleanField
-from wtforms.validators import InputRequired
+from wtforms.validators import InputRequired, Optional
 
 from CTFd.cache import clear_user_session
+from CTFd.config import process_boolean_str
 from CTFd.forms import BaseForm
 from CTFd.forms.fields import SubmitField
 from CTFd.models import Users, db
@@ -22,9 +23,10 @@ class OAuthForm(BaseForm):
     name = StringField("Client name", validators=[InputRequired()])
     client_id = StringField("OAuth client id", validators=[InputRequired()])
     client_secret = StringField("OAuth client secret", validators=[InputRequired()])
-    access_token_url = StringField("Access token url", validators=[InputRequired()])
-    authorize_url = StringField("Authorization url", validators=[InputRequired()])
-    api_base_url = StringField("User info url", validators=[InputRequired()])
+    access_token_url = StringField("Access token url", validators=[Optional()])
+    authorize_url = StringField("Authorization url", validators=[Optional()])
+    api_base_url = StringField("User info url", validators=[Optional()])
+    server_metadata_url = StringField("Server metadata url", validators=[Optional()])
     color = StringField("Button Color", validators=[InputRequired()])
     enabled = BooleanField("Enabled")
     submit = SubmitField("Add")
@@ -56,6 +58,7 @@ def load_bp(oauth):
             client.access_token_url = request.form["access_token_url"]
             client.authorize_url = request.form["authorize_url"]
             client.api_base_url = request.form["api_base_url"]
+            client.server_metadata_url = request.form["server_metadata_url"]
             client.color = request.form["color"]
             client.enabled = ("enabled" in request.form and request.form["enabled"] == "y")
             db.session.commit()
@@ -72,6 +75,7 @@ def load_bp(oauth):
           form.access_token_url.data = client.access_token_url
           form.authorize_url.data = client.authorize_url
           form.api_base_url.data = client.api_base_url
+          form.server_metadata_url.data = client.server_metadata_url
           form.color.data = client.color
           form.enabled.data = client.enabled
           form.submit.label.text = "Update"
@@ -89,9 +93,9 @@ def load_bp(oauth):
             access_token_url = request.form["access_token_url"]
             authorize_url = request.form["authorize_url"]
             api_base_url = request.form["api_base_url"]
+            server_metadata_url = request.form["server_metadata_url"]
             color = request.form["color"]
             enabled = ("enabled" in request.form and request.form["enabled"] == "y")
-
             client = OAuthClients(
                 name=name,
                 client_id=client_id,
@@ -99,6 +103,7 @@ def load_bp(oauth):
                 access_token_url=access_token_url,
                 authorize_url=authorize_url,
                 api_base_url=api_base_url,
+                server_metadata_url=server_metadata_url,
                 color=color,
                 enabled=enabled
             )
@@ -124,17 +129,26 @@ def load_bp(oauth):
     @plugin_bp.route("/sso/redirect/<int:client_id>", methods = ['GET'])
     def sso_redirect(client_id):
         client = oauth.create_client(client_id)
-        client.authorize_access_token()
-        api_data = client.get('').json()
+        token = client.authorize_access_token()
 
-        user_name = api_data["preferred_username"]
-        user_email = api_data["email"]
-        user_roles = api_data.get("roles")
+        if process_boolean_str(get_app_config("OAUTH_ALWAYS_POSSIBLE")):
+            api_data = client.get('').json()
+            user_name = api_data["preferred_username"]
+            user_email = api_data["email"]
+            user_roles = api_data.get("roles")
+        else:
+            userinfo = client.parse_id_token(token)
+            user_email = userinfo["email"]
+            if user_email.find("@") == -1:
+                user_name = user_email
+            else:
+                user_name = user_email[:user_email.find("@")]
+            user_roles = None;
 
         user = Users.query.filter_by(email=user_email).first()
         if user is None:
             # Check if we are allowing registration before creating users
-            if registration_visible() or get_app_config("OAUTH_ALWAYS_POSSIBLE") == True:
+            if registration_visible() or process_boolean_str(get_app_config("OAUTH_ALWAYS_POSSIBLE")):
                 user = Users(
                     name=user_name,
                     email=user_email,

--- a/blueprint.py
+++ b/blueprint.py
@@ -17,10 +17,67 @@ from CTFd.utils.security.auth import login_user, logout_user
 
 from .models import OAuthClients
 
+import ipaddress
 import json
+import socket
 import sys
 import time
 import requests
+from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# SSRF prevention — networks that admin-supplied metadata URLs must not reach
+# ---------------------------------------------------------------------------
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("100.64.0.0/10"),   # RFC 6598 Shared Address Space (Alibaba Cloud IMDS)
+]
+
+
+def _validate_metadata_url(url):
+    """Validate that a server_metadata_url is safe to fetch.
+
+    Raises ValueError for any URL that could be used as an SSRF vector:
+    - non-HTTPS scheme
+    - unresolvable hostname
+    - private, loopback, link-local, reserved, or cloud-metadata IP ranges
+      (covers AWS/GCP/Azure IMDSv1 at 169.254.169.254 via is_link_local,
+       RFC 1918 ranges via is_private, and Alibaba Cloud 100.100.100.200
+       via the explicit _BLOCKED_NETWORKS list)
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise ValueError("server_metadata_url must use the https scheme")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("server_metadata_url has no hostname")
+
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise ValueError(
+            f"Cannot resolve server_metadata_url hostname '{hostname}': {exc}"
+        ) from exc
+
+    for addr_info in addr_infos:
+        ip = ipaddress.ip_address(addr_info[4][0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise ValueError(
+                f"server_metadata_url resolves to a disallowed address: {ip}"
+            )
+        for net in _BLOCKED_NETWORKS:
+            if ip in net:
+                raise ValueError(
+                    f"server_metadata_url resolves to a disallowed address: {ip}"
+                )
+
 
 plugin_bp = Blueprint('sso', __name__, template_folder='templates', static_folder='static', static_url_path='/static/sso')
 
@@ -75,6 +132,7 @@ def load_bp(oauth):
 
             access_token_url = client.access_token_url
             if not access_token_url:
+                _validate_metadata_url(client.server_metadata_url)
                 metadata = requests.get(client.server_metadata_url).json()
                 access_token_url = metadata["token_endpoint"]
 
@@ -131,6 +189,7 @@ def load_bp(oauth):
             if request.form["server_metadata_url"]:
                 # Get the other URL from the server metadata site
                 client.server_metadata_url = request.form["server_metadata_url"]
+                _validate_metadata_url(client.server_metadata_url)
                 metadata = requests.get(client.server_metadata_url).json()
                 client.access_token_url = metadata["token_endpoint"]
                 client.authorize_url = metadata["authorization_endpoint"]
@@ -175,6 +234,7 @@ def load_bp(oauth):
 
             if request.form["server_metadata_url"]:
                 server_metadata_url = request.form["server_metadata_url"]
+                _validate_metadata_url(server_metadata_url)
                 metadata = requests.get(server_metadata_url).json()
                 access_token_url = metadata["token_endpoint"]
                 authorize_url = metadata["authorization_endpoint"]
@@ -369,6 +429,7 @@ def load_bp(oauth):
                 enabled = data.get("enabled", True)
                 if "server_metadata_url" in data:
                     server_metadata_url = data["server_metadata_url"]
+                    _validate_metadata_url(server_metadata_url)
                     metadata = requests.get(server_metadata_url).json()
                     access_token_url = metadata["token_endpoint"]
                     authorize_url = metadata["authorization_endpoint"]
@@ -425,6 +486,7 @@ def load_bp(oauth):
                     client.client_id = data["enabled"]
                 if "server_metadata_url" in data:
                     client.server_metadata_url = data["server_metadata_url"]
+                    _validate_metadata_url(client.server_metadata_url)
                     metadata = requests.get(client.server_metadata_url).json()
                     client.access_token_url = metadata["token_endpoint"]
                     client.authorize_url = metadata["authorization_endpoint"]

--- a/blueprint.py
+++ b/blueprint.py
@@ -124,8 +124,8 @@ def load_bp(oauth):
                 raise ValueError("SSO logout - missing refresh_token")
             refresh_token = token["refresh_token"]
 
-            if "sso_client_id" not in session:
-                client_id = session("sso_client_id")
+            if "sso_client_id" in session:
+                client_id = session["sso_client_id"]
                 client = OAuthClients.query.filter_by(id=client_id).first()
             else:
                 client = OAuthClients.query.filter_by(id=1).first()

--- a/blueprint.py
+++ b/blueprint.py
@@ -258,7 +258,7 @@ def load_bp(oauth):
         else:
             user_roles = None;
 
-        user = Users.query.filter_by(name=user_name).first()
+        user = Users.query.filter_by(email=user_email).first()
         if user is None:
             # Check if we are allowing registration before creating users
             if registration_visible():

--- a/blueprint.py
+++ b/blueprint.py
@@ -483,7 +483,7 @@ def load_bp(oauth):
                 if "color" in data:
                     client.color = data["color"]
                 if "enabled" in data:
-                    client.client_id = data["enabled"]
+                    client.enabled = data["enabled"]
                 if "server_metadata_url" in data:
                     client.server_metadata_url = data["server_metadata_url"]
                     _validate_metadata_url(client.server_metadata_url)

--- a/blueprint.py
+++ b/blueprint.py
@@ -327,7 +327,7 @@ def load_bp(oauth):
         # use the ldap.
         #
         # So use the mail by default, but allow it to be overridden by the configuration
-        if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME")) then:
+        if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)) then:
             user = Users.query.filter_by(name=user_name).first()
         else:
             user = Users.query.filter(Users.email.ilike(user_email)).first()

--- a/blueprint.py
+++ b/blueprint.py
@@ -318,7 +318,7 @@ def load_bp(oauth):
         else:
             user_roles = None;
 
-        user = Users.query.filter_by(email=user_email).first()
+        user = Users.query.filter(Users.email.ilike(user_email)).first()
         if user is None:
             # Check if we are allowing registration before creating users
             if registration_visible():

--- a/blueprint.py
+++ b/blueprint.py
@@ -357,6 +357,20 @@ def load_bp(oauth):
         user.verified = True
         db.session.commit()
 
+        # Has the users mail or username been updated ? Only treat mutable value
+        if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)) then:
+            if user_email != user.email:
+                user.type = user_role
+                db.session.commit()
+                user = Users.query.filter(Users.email.ilike(user_email)).first()
+                clear_user_session(user_id=user.id)
+        else:
+            if user_name != user.name:
+                user.name = user_name
+                db.session.commit()
+                user = Users.query.filter_by(name=user_name).first()
+                clear_user_session(user_id=user.id)
+
         if process_boolean_str(get_app_config("OAUTH_HAS_ROLES")):
             roles = get_app_config("OAUTH_ALLOWED_ADMIN_ROLES")
             if roles and not user_roles is None and len(user_roles) > 0:
@@ -383,7 +397,10 @@ def load_bp(oauth):
             if user_role != user.type:
                 user.type = user_role
                 db.session.commit()
-                user = Users.query.filter_by(email=user_email).first()
+                if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)) then:
+                    user = Users.query.filter_by(name=user_name).first()
+                else:
+                    user = Users.query.filter(Users.email.ilike(user_email)).first()
                 clear_user_session(user_id=user.id)
 
         login_user(user)

--- a/blueprint.py
+++ b/blueprint.py
@@ -318,7 +318,20 @@ def load_bp(oauth):
         else:
             user_roles = None;
 
-        user = Users.query.filter(Users.email.ilike(user_email)).first()
+        # For the vulnerability "CWE-290 — Authentication Bypass by Spoofing"
+        # we need an immutable value returned by the IdP. In most cases this
+        # will be the email address as the preferred_username can be modified
+        # on IdP's such as google. An exception is Keycloak backed by ldap used
+        # as an IdP. In that case we can and should enforce that username is
+        # immutable as changing it might cause issues with other things that
+        # use the ldap.
+        #
+        # So use the mail by default, but allow it to be overridden by the configuration
+        if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME")) then:
+            user = Users.query.filter_by(name=user_name).first()
+        else:
+            user = Users.query.filter(Users.email.ilike(user_email)).first()
+
         if user is None:
             # Check if we are allowing registration before creating users
             if registration_visible():

--- a/blueprint.py
+++ b/blueprint.py
@@ -360,15 +360,15 @@ def load_bp(oauth):
         # Has the users mail or username been updated ? Only treat mutable value
         if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)):
             if user_email != user.email:
-                user.type = user_role
+                user.email = user_email
                 db.session.commit()
-                user = Users.query.filter(Users.email.ilike(user_email)).first()
+                user = Users.query.filter_by(name=user_name).first()
                 clear_user_session(user_id=user.id)
         else:
             if user_name != user.name:
                 user.name = user_name
                 db.session.commit()
-                user = Users.query.filter_by(name=user_name).first()
+                user = Users.query.filter(Users.email.ilike(user_email)).first()
                 clear_user_session(user_id=user.id)
 
         if process_boolean_str(get_app_config("OAUTH_HAS_ROLES")):

--- a/blueprint.py
+++ b/blueprint.py
@@ -62,7 +62,7 @@ def _validate_metadata_url(url):
     for addr_info in addr_infos:
         ip = ipaddress.ip_address(addr_info[4][0])
         if (
-            ip.is_private
+            (not process_boolean_str(get_app_config("OAUTH_ALLOW_PRIVATE_METADATA", False)) and ip.is_private)
             or ip.is_loopback
             or ip.is_link_local
             or ip.is_reserved
@@ -133,9 +133,7 @@ def load_bp(oauth):
 
             access_token_url = client.access_token_url
             if not access_token_url:
-                _validate_metadata_url(client.server_metadata_url)
-                metadata = requests.get(client.server_metadata_url).json()
-                access_token_url = metadata["token_endpoint"]
+                raise ValueError("SSO logout - missing access token url")
 
             data = requests.post(access_token_url, data = {
                     "refresh_token": refresh_token,
@@ -275,13 +273,9 @@ def load_bp(oauth):
 
     @plugin_bp.route("/sso/login/<int:client_id>", methods = ['GET'])
     def sso_oauth(client_id):
-        client = OAuthClients.query.filter_by(id=client_id).first()
         oauth_client = oauth.create_client(client_id)
         redirect_uri=url_for('sso.sso_redirect', client_id=client_id, _external=True, _scheme='https')
-        if client.pkce_s256:
-            return oauth_client.authorize_redirect(redirect_uri, code_challenge_method="S256")
-        else:
-            return oauth_client.authorize_redirect(redirect_uri)
+        return oauth_client.authorize_redirect(redirect_uri)
 
     @plugin_bp.route("/sso/redirect/<int:client_id>", methods = ['GET'])
     def sso_redirect(client_id):

--- a/blueprint.py
+++ b/blueprint.py
@@ -327,7 +327,7 @@ def load_bp(oauth):
         # use the ldap.
         #
         # So use the mail by default, but allow it to be overridden by the configuration
-        if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)) then:
+        if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)):
             user = Users.query.filter_by(name=user_name).first()
         else:
             user = Users.query.filter(Users.email.ilike(user_email)).first()
@@ -358,7 +358,7 @@ def load_bp(oauth):
         db.session.commit()
 
         # Has the users mail or username been updated ? Only treat mutable value
-        if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)) then:
+        if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)):
             if user_email != user.email:
                 user.type = user_role
                 db.session.commit()
@@ -397,7 +397,7 @@ def load_bp(oauth):
             if user_role != user.type:
                 user.type = user_role
                 db.session.commit()
-                if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)) then:
+                if process_boolean_str(get_app_config("OAUTH_VALIDATE_WITH_USERNAME", False)):
                     user = Users.query.filter_by(name=user_name).first()
                 else:
                     user = Users.query.filter(Users.email.ilike(user_email)).first()

--- a/blueprint.py
+++ b/blueprint.py
@@ -91,6 +91,7 @@ class OAuthForm(BaseForm):
     api_base_url = StringField("Realm url", validators=[Optional()])
     server_metadata_url = StringField("Server metadata url", validators=[Optional()])
     color = StringField("Button Color", validators=[InputRequired()])
+    pkce_s256 = BooleanField("Use PKCE S256 challenge")
     enabled = BooleanField("Enabled")
     submit = SubmitField("Add")
 
@@ -185,6 +186,7 @@ def load_bp(oauth):
             client.client_id = request.form["client_id"]
             client.client_secret = request.form["client_secret"]
             client.color = request.form["color"]
+            client.pkce_s256 = ("pkce_s256" in request.form and request.form["pkce_s256"] == "y")
             client.enabled = ("enabled" in request.form and request.form["enabled"] == "y")
             if request.form["server_metadata_url"]:
                 # Get the other URL from the server metadata site
@@ -216,6 +218,7 @@ def load_bp(oauth):
           form.api_base_url.data = client.api_base_url
           form.server_metadata_url.data = client.server_metadata_url
           form.color.data = client.color
+          form.pkce_s256.data = client.pkce_s256
           form.enabled.data = client.enabled
           form.submit.label.text = "Update"
 
@@ -230,6 +233,7 @@ def load_bp(oauth):
             client_id = request.form["client_id"]
             client_secret = request.form["client_secret"]
             color = request.form["color"]
+            pkce_s256 = ("pkce_s256" in request.form and request.form["pkce_s256"] == "y")
             enabled = ("enabled" in request.form and request.form["enabled"] == "y")
 
             if request.form["server_metadata_url"]:
@@ -255,6 +259,7 @@ def load_bp(oauth):
                 api_base_url=api_base_url,
                 server_metadata_url=server_metadata_url,
                 color=color,
+                pkce_s256=pkce_s256,
                 enabled=enabled
             )
             db.session.add(client)
@@ -268,13 +273,15 @@ def load_bp(oauth):
         form = OAuthForm()
         return render_template('create.html', form=form)
 
-
     @plugin_bp.route("/sso/login/<int:client_id>", methods = ['GET'])
     def sso_oauth(client_id):
-        client = oauth.create_client(client_id)
+        client = OAuthClients.query.filter_by(id=client_id).first()
+        oauth_client = oauth.create_client(client_id)
         redirect_uri=url_for('sso.sso_redirect', client_id=client_id, _external=True, _scheme='https')
-        return client.authorize_redirect(redirect_uri)
-
+        if client.pkce_s256:
+            return oauth_client.authorize_redirect(redirect_uri, code_challenge_method="S256")
+        else:
+            return oauth_client.authorize_redirect(redirect_uri)
 
     @plugin_bp.route("/sso/redirect/<int:client_id>", methods = ['GET'])
     def sso_redirect(client_id):
@@ -456,6 +463,7 @@ def load_bp(oauth):
                 client_id = data.get("client_id", "")
                 client_secret = data.get("client_secret", "")
                 color = data.get("color", "")
+                pkce_s256 = data.get("pkce_s256", False)
                 enabled = data.get("enabled", True)
                 if "server_metadata_url" in data:
                     server_metadata_url = data["server_metadata_url"]
@@ -480,6 +488,7 @@ def load_bp(oauth):
                     api_base_url=api_base_url,
                     server_metadata_url=server_metadata_url,
                     color=color,
+                    pkce_s256=pkce_s256,
                     enabled=enabled
                 )
                 db.session.add(client)
@@ -512,6 +521,8 @@ def load_bp(oauth):
                     client.client_secret = data["client_secret"]
                 if "color" in data:
                     client.color = data["color"]
+                if "pkce_s256" in data:
+                    client.pkce_s256 = data["pkce_s256"]                    
                 if "enabled" in data:
                     client.enabled = data["enabled"]
                 if "server_metadata_url" in data:

--- a/models.py
+++ b/models.py
@@ -23,7 +23,7 @@ class OAuthClients(db.Model):
     enabled = db.Column(db.Boolean, default=False)
 
     def register(self, oauth):
-        if process_boolean_str(get_app_config("OAUTH_ALWAYS_POSSIBLE")):
+        if process_boolean_str(get_app_config("OAUTH_HAS_ROLES")):
           scope = 'profile openid  roles'
         else:
           scope = 'profile openid email'

--- a/models.py
+++ b/models.py
@@ -1,7 +1,10 @@
 from CTFd.config import process_boolean_str
 from CTFd.models import db
 from CTFd.utils import get_app_config
+#from authlib.integrations.flask_client import token_update
 
+def fetch_token():
+    return request.cookies.get("token")
 
 class OAuthClients(db.Model):
     __tablename__ = "oauth_clients"
@@ -34,6 +37,7 @@ class OAuthClients(db.Model):
                 client_id=self.client_id,
                 client_secret=self.client_secret,
                 server_metadata_url=self.server_metadata_url,
+                fetch_token=fetch_token,
                 client_kwargs={'scope': scope}
             )
         else:
@@ -45,6 +49,7 @@ class OAuthClients(db.Model):
                 authorize_url=self.authorize_url,
                 api_base_url=self.api_base_url,
                 server_metadata_url=f'{self.api_base_url}/.well-known/openid-configuration',
+                fetch_token=fetch_token,
                 client_kwargs={'scope': scope}
             )
 

--- a/models.py
+++ b/models.py
@@ -1,7 +1,7 @@
 from CTFd.config import process_boolean_str
 from CTFd.models import db
 from CTFd.utils import get_app_config
-#from authlib.integrations.flask_client import token_update
+import json
 
 def fetch_token():
     return request.cookies.get("token")
@@ -46,3 +46,16 @@ class OAuthClients(db.Model):
     def disconnect(self, oauth):
         oauth._registry[self.id] = None
         oauth._clients[self.id] = None
+
+    def json(self):
+        return {'id': self.id, 
+                'name': self.name,
+                'client_id' : self.client_id,
+                'client_secret': self.client_secret,
+                'access_token_url': self.access_token_url,
+                'authorize_url': self.authorize_url,
+                'api_base_url': self.api_base_url,
+                'server_metadata_url': self.server_metadata_url,
+                'color': self.color,
+                'icon': self.icon,
+                'enabled': self.enabled}

--- a/models.py
+++ b/models.py
@@ -31,27 +31,17 @@ class OAuthClients(db.Model):
         else:
           scope = 'profile openid email'
 
-        if self.server_metadata_url:
-            oauth.register(
-                name=self.id,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                server_metadata_url=self.server_metadata_url,
-                fetch_token=fetch_token,
-                client_kwargs={'scope': scope}
-            )
-        else:
-            oauth.register(
-                name=self.id,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                access_token_url=self.access_token_url,
-                authorize_url=self.authorize_url,
-                api_base_url=self.api_base_url,
-                server_metadata_url=f'{self.api_base_url}/.well-known/openid-configuration',
-                fetch_token=fetch_token,
-                client_kwargs={'scope': scope}
-            )
+        oauth.register(
+            name=self.id,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            access_token_url=self.access_token_url,
+            authorize_url=self.authorize_url,
+            api_base_url=self.api_base_url,
+            server_metadata_url=self.server_metadata_url,
+            fetch_token=fetch_token,
+            client_kwargs={'scope': scope}
+        )
 
     def disconnect(self, oauth):
         oauth._registry[self.id] = None

--- a/models.py
+++ b/models.py
@@ -1,4 +1,6 @@
+from CTFd.config import process_boolean_str
 from CTFd.models import db
+from CTFd.utils import get_app_config
 
 
 class OAuthClients(db.Model):
@@ -20,6 +22,10 @@ class OAuthClients(db.Model):
     enabled = db.Column(db.Boolean, default=False)
 
     def register(self, oauth):
+        if process_boolean_str(get_app_config("OAUTH_ALWAYS_POSSIBLE")):
+          scope = 'profile roles'
+        else:
+          scope = 'profile'
         oauth.register(
             name=self.id,
             client_id=self.client_id,
@@ -27,7 +33,7 @@ class OAuthClients(db.Model):
             access_token_url=self.access_token_url,
             authorize_url=self.authorize_url,
             api_base_url=self.api_base_url,
-            client_kwargs={'scope': 'profile roles'}
+            client_kwargs={'scope': scope}
         )
 
     def disconnect(self, oauth):

--- a/models.py
+++ b/models.py
@@ -16,19 +16,10 @@ class OAuthClients(db.Model):
     color = db.Column(db.Text)
     icon = db.Column(db.Text)
 
-    def register(self, oauth):
-        oauth.register(
-            name=self.id,
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            access_token_url=self.access_token_url,
-            authorize_url=self.authorize_url,
-            api_base_url=self.api_base_url,
-            client_kwargs={'scope': 'profile roles'}
-        )
+    # Allow the OAuth provider to be individually enabled/disabled
+    enabled = db.Column(db.Boolean, default=False)
 
-    def update(self, oauth):
-        oauth._registry.pop(self.name)
+    def register(self, oauth):
         oauth.register(
             name=self.id,
             client_id=self.client_id,

--- a/models.py
+++ b/models.py
@@ -27,7 +27,7 @@ class OAuthClients(db.Model):
 
     def register(self, oauth):
         if process_boolean_str(get_app_config("OAUTH_HAS_ROLES")):
-          scope = 'profile openid  roles'
+          scope = 'profile openid roles'
         else:
           scope = 'profile openid email'
 

--- a/models.py
+++ b/models.py
@@ -27,6 +27,18 @@ class OAuthClients(db.Model):
             client_kwargs={'scope': 'profile roles'}
         )
 
+    def update(self, oauth):
+        oauth._registry.pop(self.name)
+        oauth.register(
+            name=self.id,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            access_token_url=self.access_token_url,
+            authorize_url=self.authorize_url,
+            api_base_url=self.api_base_url,
+            client_kwargs={'scope': 'profile roles'}
+        )
+
     def disconnect(self, oauth):
         oauth._registry[self.id] = None
         oauth._clients[self.id] = None

--- a/models.py
+++ b/models.py
@@ -27,7 +27,7 @@ class OAuthClients(db.Model):
 
     def register(self, oauth):
         if process_boolean_str(get_app_config("OAUTH_HAS_ROLES")):
-          scope = 'profile openid roles'
+          scope = 'profile openid email roles'
         else:
           scope = 'profile openid email'
 

--- a/models.py
+++ b/models.py
@@ -48,10 +48,9 @@ class OAuthClients(db.Model):
         oauth._clients[self.id] = None
 
     def json(self):
-        return {'id': self.id, 
+        return {'id': self.id,
                 'name': self.name,
                 'client_id' : self.client_id,
-                'client_secret': self.client_secret,
                 'access_token_url': self.access_token_url,
                 'authorize_url': self.authorize_url,
                 'api_base_url': self.api_base_url,

--- a/models.py
+++ b/models.py
@@ -18,6 +18,9 @@ class OAuthClients(db.Model):
     api_base_url = db.Column(db.Text)
     server_metadata_url = db.Column(db.Text)
 
+    # Do we use S256 PKCE challenges
+    pkce_s256 = db.Column(db.Boolean, default=False)
+
     # In a later update you will be able to customize the login button 
     color = db.Column(db.Text)
     icon = db.Column(db.Text)
@@ -57,4 +60,5 @@ class OAuthClients(db.Model):
                 'server_metadata_url': self.server_metadata_url,
                 'color': self.color,
                 'icon': self.icon,
+                'pkce_s256': self.pkce_s256,
                 'enabled': self.enabled}

--- a/models.py
+++ b/models.py
@@ -38,6 +38,7 @@ class OAuthClients(db.Model):
             name=self.id,
             client_id=self.client_id,
             client_secret=self.client_secret,
+            code_challenge_method="S256" if self.pkce_s256 else None,
             access_token_url=self.access_token_url,
             authorize_url=self.authorize_url,
             api_base_url=self.api_base_url,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Authlib==0.15.4
+Authlib==1.6.0

--- a/static/css/sso.css
+++ b/static/css/sso.css
@@ -1,0 +1,22 @@
+hr.hr-text {
+  position: relative;
+    border: none;
+    height: 1px;
+    background-color: #999;
+}
+
+hr.hr-text::before {
+    content: attr(data-content);
+    display: inline-block;
+    background: #fff;
+    color: #999;
+    font-weight: bold;
+    font-size: 0.85rem;
+    border-radius: 30rem;
+    padding: 0.2rem 2rem;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+

--- a/static/js/challenges_sso.js
+++ b/static/js/challenges_sso.js
@@ -1,0 +1,22 @@
+async function isSSOLoggedIn() {
+  CTFd.fetch("/api/v1/users/me", {
+    method: "GET",
+    credentials: "same-origin",
+    headers: {"Accept": "application/json",},
+  }).then((response) => {
+    return response.json();
+  }).catch(() => {
+    window.location =
+      CTFd.config.urlRoot +
+      "/login?next=" +
+      CTFd.config.urlRoot +
+      window.location.pathname +
+      window.location.hash;
+  });
+}
+
+setInterval(() = {
+  Array.prototype.forEach.call(document.getElementsByClassName("challenge-button"), (chall) =>
+      chall.addEventListener("click", isSSOLoggedIn); 
+}, 100);
+

--- a/static/js/challenges_sso.js
+++ b/static/js/challenges_sso.js
@@ -6,13 +6,12 @@ document.body.addEventListener("click", () => {
   }).then((response) => {
     return response.json();
   }).then((response) => {
-    if (! response.success) throw new Error("SSO logout")
-  }).catch(() => {
-    window.location =
-      CTFd.config.urlRoot +
-      "/login?next=" +
-      CTFd.config.urlRoot +
-      window.location.pathname +
-      window.location.hash;
-  });
+    if (! response.success)
+      window.location =    
+        CTFd.config.urlRoot +
+        "/login?next=" +     
+        CTFd.config.urlRoot +
+        window.location.pathname +
+        window.location.hash;     
+  });                        
 }, false);

--- a/static/js/challenges_sso.js
+++ b/static/js/challenges_sso.js
@@ -1,10 +1,12 @@
-async function isSSOLoggedIn() {
+document.body.addEventListener("click", () => {
   CTFd.fetch("/api/v1/users/me", {
     method: "GET",
     credentials: "same-origin",
     headers: {"Accept": "application/json",},
   }).then((response) => {
     return response.json();
+  }).then((response) => {
+    if (! response.success) throw new Error("SSO logout")
   }).catch(() => {
     window.location =
       CTFd.config.urlRoot +
@@ -13,10 +15,4 @@ async function isSSOLoggedIn() {
       window.location.pathname +
       window.location.hash;
   });
-}
-
-setInterval(() = {
-  Array.prototype.forEach.call(document.getElementsByClassName("challenge-button"), (chall) =>
-      chall.addEventListener("click", isSSOLoggedIn); 
-}, 100);
-
+}, false);

--- a/templates/challenges_sso.html
+++ b/templates/challenges_sso.html
@@ -1,0 +1,1 @@
+<script defer src="{{ url_for('sso.static', filename='js/challenges_sso.js') }}"></script>

--- a/templates/create.html
+++ b/templates/create.html
@@ -1,5 +1,9 @@
 {% extends "admin/base.html" %}
 
+{% block stylesheets %}
+<link rel="stylesheet" type="text/css" href="{{ url_for('sso.static', filename='css/sso.css') }}">
+{% endblock %}
+
 {% block content %}
 <div class="jumbotron">
 	<div class="container">
@@ -24,6 +28,7 @@
 					<b>{{ form.client_secret.label }}</b>
 					{{ form.client_secret(class="form-control", value=client_secret) }}
 				</div>
+				<hr color="#999">
 				<div class="form-group">
 					<b>{{ form.access_token_url.label }}</b>
 					{{ form.access_token_url(class="form-control", value=access_token_url) }}
@@ -36,6 +41,12 @@
 					<b>{{ form.api_base_url.label }}</b>
 					{{ form.api_base_url(class="form-control", value=api_base_url) }}
 				</div>
+				<hr class="hr-text" data-content="Or">
+				<div class="form-group">
+					<b>{{ form.server_metadata_url.label }}</b>
+					{{ form.server_metadata_url(class="form-control", value=server_metadata_url) }}
+				</div>
+        <hr color="#999">
 				<div class="form-group">
 				  <b>{{ form.color.label }}</b>
 				  <input type="color" id="color" name="color" value="#7f7f7f">

--- a/templates/create.html
+++ b/templates/create.html
@@ -36,6 +36,10 @@
 					<b>{{ form.api_base_url.label }}</b>
 					{{ form.api_base_url(class="form-control", value=api_base_url) }}
 				</div>
+				<div class="form-group">
+				  <b>{{ form.enabled.label }}</b>
+				  {{ form.enabled }}
+				</div>
 				<div class="row">
 					<div class="col">
 						{{ form.submit(class="btn btn-md btn-primary btn-outlined") }}

--- a/templates/create.html
+++ b/templates/create.html
@@ -37,6 +37,10 @@
 					{{ form.api_base_url(class="form-control", value=api_base_url) }}
 				</div>
 				<div class="form-group">
+				  <b>{{ form.color.label }}</b>
+				  <input type="color" id="color" name="color" value="#7f7f7f">
+				</div>
+				<div class="form-group">
 				  <b>{{ form.enabled.label }}</b>
 				  {{ form.enabled }}
 				</div>

--- a/templates/create.html
+++ b/templates/create.html
@@ -21,29 +21,29 @@
 					{{ form.name(class="form-control", value=name) }}
 				</div>
 				<div class="form-group">
-					<b>{{ form.client_id.label }}</b>
+					<b>{{ form.client_id.label }} (self-explanatory)</b>
 					{{ form.client_id(class="form-control", value=client_id) }}
 				</div>
 				<div class="form-group">
-					<b>{{ form.client_secret.label }}</b>
+					<b>{{ form.client_secret.label }} (self-explanatory)</b>
 					{{ form.client_secret(class="form-control", value=client_secret) }}
 				</div>
 				<hr color="#999">
 				<div class="form-group">
-					<b>{{ form.access_token_url.label }}</b>
+					<b>{{ form.access_token_url.label }} (Authentik: Token URL)</b>
 					{{ form.access_token_url(class="form-control", value=access_token_url) }}
 				</div>
 				<div class="form-group">
-					<b>{{ form.authorize_url.label }}</b>
+					<b>{{ form.authorize_url.label }} (Authentik: Authorize URL)</b>
 					{{ form.authorize_url(class="form-control", value=authorize_url) }}
 				</div>
 				<div class="form-group">
-					<b>{{ form.api_base_url.label }}</b>
+					<b>{{ form.api_base_url.label }} (Authentik: OpenID Configuration Issuer)</b>
 					{{ form.api_base_url(class="form-control", value=api_base_url) }}
 				</div>
 				<hr class="hr-text" data-content="Or">
 				<div class="form-group">
-					<b>{{ form.server_metadata_url.label }}</b>
+					<b>{{ form.server_metadata_url.label }} (Authentik: OpenID Configuration URL)</b>
 					{{ form.server_metadata_url(class="form-control", value=server_metadata_url) }}
 				</div>
         <hr color="#999">

--- a/templates/create.html
+++ b/templates/create.html
@@ -48,6 +48,10 @@
 				</div>
         <hr color="#999">
 				<div class="form-group">
+				  <b>{{ form.pkce_s256.label }}</b>
+				  {{ form.pkce_s256 }}
+				</div>
+				<div class="form-group">
 				  <b>{{ form.color.label }}</b>
 				  <input type="color" id="color" name="color" value="#7f7f7f">
 				</div>

--- a/templates/list.html
+++ b/templates/list.html
@@ -39,6 +39,7 @@
 						</td>
 						<th class="sort-col text-center"><b>ID</b></th>
 						<th class="sort-col"><b>Name</b></th>
+						<th class="sort-col"><b>Enabled</b></th>
 					</tr>
 					</thead>
 					<tbody>
@@ -51,6 +52,12 @@
 							</td>
 							<td class="text-center">{{ client.id }}</td>
 							<td><a href="{{ url_for('sso.sso_details', client_id=client.id) }}">{{ client.name }}</a></td>
+							<td>
+								{% set badge_state = 'badge-success' if client.enabled else 'badge-danger' %}
+								<span class="badge {{ badge_state }}">
+								  {% if client.enabled %}enabled{% else %}disabled{% endif %}
+								</span>
+							</td>
 						</tr>
 					{% endfor %}
 					</tbody>

--- a/templates/list.html
+++ b/templates/list.html
@@ -39,6 +39,7 @@
 						</td>
 						<th class="sort-col text-center"><b>ID</b></th>
 						<th class="sort-col"><b>Name</b></th>
+						<th><b>Color</b></th>
 						<th class="sort-col"><b>Enabled</b></th>
 					</tr>
 					</thead>
@@ -52,6 +53,7 @@
 							</td>
 							<td class="text-center">{{ client.id }}</td>
 							<td><a href="{{ url_for('sso.sso_details', client_id=client.id) }}">{{ client.name }}</a></td>
+							<td><svg viewBox="0 0 120 30"><rect x="5" y="5" width="100" height="20" style="fill: {{ client.color }}"></td>
 							<td>
 								{% set badge_state = 'badge-success' if client.enabled else 'badge-danger' %}
 								<span class="badge {{ badge_state }}">

--- a/templates/login_oauth.html
+++ b/templates/login_oauth.html
@@ -1,6 +1,7 @@
 {% for client in oauth_clients() %}
   {% if client.enabled %}
-<a class="btn btn-secondary btn-lg btn-block" href="{{ url_for('sso.sso_oauth', client_id=client.id) }}">
+<style>.btn-{{ client.id }} { background-color: {{ client.color }}; color: #ffffff }</style>
+<a class="btn btn-{{ client.id }} btn-lg btn-block" color="{{client.color }}" href="{{ url_for('sso.sso_oauth', client_id=client.id) }}">
     Log in with {{ client.name }}
 </a>
   {%endif %}

--- a/templates/login_oauth.html
+++ b/templates/login_oauth.html
@@ -1,7 +1,8 @@
 {% for client in oauth_clients() %}
+  {% if client.enabled %}
 <a class="btn btn-secondary btn-lg btn-block" href="{{ url_for('sso.sso_oauth', client_id=client.id) }}">
     Log in with {{ client.name }}
 </a>
-
+  {%endif %}
 <hr>
 {% endfor %}

--- a/templates/login_oauth_no_local.html
+++ b/templates/login_oauth_no_local.html
@@ -6,7 +6,8 @@
 {% else %}
 {% for client in oauth_clients() %}
   {% if client.enabled %}
-<a class="btn btn-secondary btn-lg btn-block" href="{{ url_for('sso.sso_oauth', client_id=client.id) }}">
+<style>.btn-{{ client.id }} { background-color: {{ client.color }}; color: #ffffff }</style>
+<a class="btn btn-{{ client.id }} btn-lg btn-block" color="{{client.color }}" href="{{ url_for('sso.sso_oauth', client_id=client.id) }}">
     Log in with {{ client.name }}
 </a>
   {% endif %}

--- a/templates/login_oauth_no_local.html
+++ b/templates/login_oauth_no_local.html
@@ -1,0 +1,15 @@
+{% if numactive(oauth_clients()) == 1 %}
+<!-- Only one OAuth provider active and no local users. Auto redirect -->
+<script type="text/javascript">
+    window.location.href = "{{ url_for('sso.sso_oauth', client_id=oauth_clients()[0].id) }}";
+</script>
+{% else %}
+{% for client in oauth_clients() %}
+  {% if client.enabled %}
+<a class="btn btn-secondary btn-lg btn-block" href="{{ url_for('sso.sso_oauth', client_id=client.id) }}">
+    Log in with {{ client.name }}
+</a>
+  {% endif %}
+<hr>
+{% endfor %}
+{% endif %}

--- a/templates/update.html
+++ b/templates/update.html
@@ -1,5 +1,9 @@
 {% extends "admin/base.html" %}
 
+{% block stylesheets %}
+<link rel="stylesheet" type="text/css" href="{{ url_for('sso.static', filename='css/sso.css') }}">
+{% endblock %}
+
 {% block content %}
 <div class="jumbotron">
 	<div class="container">

--- a/templates/update.html
+++ b/templates/update.html
@@ -1,0 +1,49 @@
+{% extends "admin/base.html" %}
+
+{% block content %}
+<div class="jumbotron">
+	<div class="container">
+		<h1>Update OAuth2 client</h1>
+	</div>
+</div>
+<div class="container">
+	<div class="row">
+		<div class="col-md-6 offset-md-3">
+			{% include "components/errors.html" %}
+
+			<form method="post" accept-charset="utf-8" autocomplete="off">
+				<div class="form-group">
+					<b>{{ form.name.label }}</b>
+					{{ form.name(class="form-control", value=form.name.data, disabled=True) }}
+				</div>
+				<div class="form-group">
+					<b>{{ form.client_id.label }}</b>
+					{{ form.client_id(class="form-control", value=form.client_id.data or "") }}
+				</div>
+				<div class="form-group">
+					<b>{{ form.client_secret.label }}</b>
+					{{ form.client_secret(class="form-control", value=form.client_secret.data or "") }}
+				</div>
+				<div class="form-group">
+					<b>{{ form.access_token_url.label }}</b>
+					{{ form.access_token_url(class="form-control", value=form.access_token_url.data or "") }}
+				</div>
+				<div class="form-group">
+					<b>{{ form.authorize_url.label }}</b>
+					{{ form.authorize_url(class="form-control", value=form.authorize_url.data or "") }}
+				</div>
+				<div class="form-group">
+					<b>{{ form.api_base_url.label }}</b>
+					{{ form.api_base_url(class="form-control", value=form.api_base_url.data or "") }}
+				</div>
+				<div class="row">
+					<div class="col">
+						{{ form.submit(class="btn btn-md btn-primary btn-outlined") }}
+					</div>
+				</div>
+				{{ form.nonce() }}
+			</form>
+		</div>
+	</div>
+</div>
+{% endblock %}

--- a/templates/update.html
+++ b/templates/update.html
@@ -37,6 +37,10 @@
 					{{ form.api_base_url(class="form-control", value=form.api_base_url.data or "") }}
 				</div>
 				<div class="form-group">
+				  <b>{{ form.color.label }}</b>
+				  <input type="color" id)"color" name="color" value="{{ form.color.data }}">
+				</div>				
+				<div class="form-group">
 				  <b>{{ form.enabled.label }}</b>
 				  {{ form.enabled }}
 				</div>

--- a/templates/update.html
+++ b/templates/update.html
@@ -24,6 +24,7 @@
 					<b>{{ form.client_secret.label }}</b>
 					{{ form.client_secret(class="form-control", value=form.client_secret.data or "") }}
 				</div>
+				<hr color="#999">
 				<div class="form-group">
 					<b>{{ form.access_token_url.label }}</b>
 					{{ form.access_token_url(class="form-control", value=form.access_token_url.data or "") }}
@@ -36,6 +37,12 @@
 					<b>{{ form.api_base_url.label }}</b>
 					{{ form.api_base_url(class="form-control", value=form.api_base_url.data or "") }}
 				</div>
+				<hr class="hr-text" data-content="Or">
+				<div class="form-group">
+					<b>{{ form.server_metadata_url.label }}</b>
+					{{ form.server_metadata_url(class="form-control", value=server_metadata_url) }}
+				</div>
+        <hr color="#999">
 				<div class="form-group">
 				  <b>{{ form.color.label }}</b>
 				  <input type="color" id)"color" name="color" value="{{ form.color.data }}">

--- a/templates/update.html
+++ b/templates/update.html
@@ -36,6 +36,10 @@
 					<b>{{ form.api_base_url.label }}</b>
 					{{ form.api_base_url(class="form-control", value=form.api_base_url.data or "") }}
 				</div>
+				<div class="form-group">
+				  <b>{{ form.enabled.label }}</b>
+				  {{ form.enabled }}
+				</div>
 				<div class="row">
 					<div class="col">
 						{{ form.submit(class="btn btn-md btn-primary btn-outlined") }}

--- a/templates/update.html
+++ b/templates/update.html
@@ -44,7 +44,7 @@
 				<hr class="hr-text" data-content="Or">
 				<div class="form-group">
 					<b>{{ form.server_metadata_url.label }}</b>
-					{{ form.server_metadata_url(class="form-control", value=server_metadata_url) }}
+					{{ form.server_metadata_url(class="form-control", value=form.server_metadata_url.data or "") }}
 				</div>
         <hr color="#999">
 				<div class="form-group">

--- a/templates/update.html
+++ b/templates/update.html
@@ -48,6 +48,10 @@
 				</div>
         <hr color="#999">
 				<div class="form-group">
+				  <b>{{ form.pkce_s256.label }}</b>
+				  {{ form.pkce_s256 }}
+				</div>
+				<div class="form-group">
 				  <b>{{ form.color.label }}</b>
 				  <input type="color" id)"color" name="color" value="{{ form.color.data }}">
 				</div>				


### PR DESCRIPTION
This pull request includes several changes that

- Allow GET and POST on /sso/client/<client_id> and supply the means to update the OAuth provider.
- Allow providers to be disabled, so thet aren't used, but can be reactived later
- Possibility to change the button color for each provider individually. Haven't done the icon yet, but the CTFd media library modal can surely be used
-  Remove the OAUTH_ALWAYS_POSSIBLE as in this case the CTFd should be configure to allow it
- Add OAUTH_HAS_ROLES to define if "roles" should be included in the scope, otherwise the user is created from the userinfo field of the id_token
- Allow server_metadata_url to be used rather than entering all of the endpoints individually
- Allow the local accounts to be disabled. If only one OAuth provider is included then the redirect to the OAuth provider is automatic
- Use process_boolean_str on configuration values to allow arbitrary means of activating this parameters (true, True, 1,  y, etc)

I hesitated to add an OAuth logout to the CTFd logout but finally don't think its a good idea in an SSO environment.